### PR TITLE
add jbang-catalog

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,14 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "jarkanoid": {
+      "script-ref": "https://github.com/HanSolo/jarkanoid/releases/download/17.0.7/jarkanoid-mac-x64-17.0.7.jar",
+      "dependencies": [
+        "org.openjfx:javafx-controls:18.0.2:${os.detected.jfxname}",
+        "org.openjfx:javafx-media:18.0.2:${os.detected.jfxname}"
+      ],
+      "java": "17"
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
with this catalog you can run:

`jbang jarkanoid@hansolo/jarkanoid`

draft for now as needs 0.103.2 of jbang released to work magically on M1 macs + it currently uses a macos release jar but since I add the proper OS deps first it works (but would be nicer with the general jar published under releases or available in maven)

wdyt?

alternatively you can make a HanSolo/jbang-catalog repo and it can be shortened to `jbang jarkanoid@hansoloe`